### PR TITLE
Fix console menu import and source file path

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import os
-# This line was likely missing from your file
-from console_menu import ConsoleMenu, MenuItem
+# Use the `consolemenu` package for interactive CLI menus
+from consolemenu import ConsoleMenu
+from consolemenu.items import MenuItem
 import converter
 import player
 
@@ -8,7 +9,8 @@ import player
 # Directory where your final .txt song files are stored
 SONGS_DIR = "songs"
 # Directory where your source .mid and .mxl files are located
-SOURCE_FILES_DIR = r"C:\Users\domef\OneDrive\Desktop\HPMA_Piano_v2\source_files"
+# Default to the local `source_files` folder so the project works cross-platform
+SOURCE_FILES_DIR = "source_files"
 
 def create_songs_directory():
     """Creates the 'songs' directory if it doesn't already exist."""


### PR DESCRIPTION
## Summary
- fix import path for ConsoleMenu
- use relative source_files directory by default

## Testing
- `python -m py_compile converter.py main.py player.py key_mapper.py`
- `pip install -r requirements.txt` *(fails: DISPLAY not set)*

------
https://chatgpt.com/codex/tasks/task_e_687bcf7ec5bc83299eae5a3a965ac7e3