### PR TITLE
Remove window focusing and add countdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ lua mxl_to_lua.lua song.txt song.lua
 python main.py
 
 # Select a song from the menu
-# Switch to your piano game when prompted
+# After selecting a song, switch to your piano game before the countdown ends
 ```
 
 ### Option 3: Test the System
@@ -147,7 +147,7 @@ STANDARD_OCTAVE_TO_CUSTOM_OCTAVE = {
 
 ## 🎮 Gaming Tips
 
-1. **Window Focus**: Make sure your piano game is the active window before playback starts
+1. **Window Focus**: Ensure your piano game is active before the 3‑second countdown finishes
 2. **Failsafe**: Move mouse to top-left corner to stop playback immediately
 3. **Timing**: Adjust `TEMPO_BPM` if the music plays too fast/slow
 4. **Practice**: Test with short songs first to calibrate timing
@@ -187,7 +187,7 @@ STANDARD_OCTAVE_TO_CUSTOM_OCTAVE = {
 ## ⚠️ Important Notes
 
 - This script sends keyboard inputs to whatever window is active
-- Make sure your piano game is focused before playback
+- Make sure your piano game is focused before the countdown ends
 - Some games may have anti-automation protection
 - Test with simple songs first
 - Use responsibly and follow game terms of service

--- a/main.py
+++ b/main.py
@@ -54,12 +54,8 @@ def run_player():
     selected_song = song_files[selected_song_index]
     song_path = os.path.join(SONGS_DIR, selected_song)
 
-    window_title = input("\nEnter the exact title of the game/piano window: ")
-    if not window_title:
-        print("Window title cannot be empty.")
-        return
-        
-    player.play_song(song_path, window_title)
+    print("\nAfter selecting a song, quickly switch to your game window.")
+    player.play_song(song_path)
     input("\nPress Enter to return to the main menu.")
 
 def run_converter():

--- a/player.py
+++ b/player.py
@@ -2,37 +2,21 @@
 
 import pyautogui
 import time
-import pywinctl as gw
 from key_mapper import NOTE_TO_KEY
 
 # Fail-safe: moving mouse to a corner will stop the script
 pyautogui.FAILSAFE = True
 
-def play_song(song_path, window_title):
-    """
-    Plays a song from a .txt file by sending keystrokes to a target window.
+def play_song(song_path):
+    """Plays a song from a .txt file by sending keystrokes to the active window.
+
+    The user should manually focus the target game window before the countdown
+    ends.
 
     Args:
         song_path (str): The path to the .txt song file.
-        window_title (str): The title of the window to send keystrokes to.
     """
-    # --- 1. Find and Activate Target Window ---
-    try:
-        target_window = gw.getWindowsWithTitle(window_title)
-        if not target_window:
-            print(f"Error: Window '{window_title}' not found.")
-            return
-        
-        # Activate the window to ensure it has focus
-        target_window[0].activate()
-        print(f"Successfully focused window: '{window_title}'")
-        
-    except Exception as e:
-        print(f"Error interacting with window: {e}")
-        print("Please ensure the window title is correct and the application is running.")
-        return
-
-    # --- 2. Load and Parse Song File ---
+    # --- 1. Load and Parse Song File ---
     try:
         with open(song_path, 'r') as f:
             lines = f.readlines()
@@ -51,9 +35,9 @@ def play_song(song_path, window_title):
     beat_duration = 60.0 / tempo
     print(f"Playing '{song_path}' at {tempo} BPM (beat duration: {beat_duration:.2f}s)")
 
-    # --- 3. Countdown and Play ---
-    print("Starting in:")
-    for i in range(5, 0, -1):
+    # --- 2. Countdown and Play ---
+    print("Switch to your game window now! Starting in:")
+    for i in range(3, 0, -1):
         print(f"{i}...")
         time.sleep(1)
     print("Playing now!")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 music21
 pyautogui
 Pillow
-PyWinCtl
 console-menu


### PR DESCRIPTION
## Summary
- simplify playback: no game window title required
- add 3‑second countdown and update instructions
- remove PyWinCtl dependency

## Testing
- `python -m py_compile *.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687bdc2ea1b48329887927a25aec172b