### PR TITLE
Improve converter accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,20 @@ HPMA_Piano/
 
 ### Quick Start
 1. **Run the demo/guide**: `python demo.py`
-2. **Convert .mxl to song file**: `python convert_mxl_dual_clef.py your_file.mxl`
+2. **Convert .mxl to song file**: run `python main.py` and choose the
+   **Convert** option to process your MusicXML or MIDI file.
 3. **Play songs**: `python main.py`
 
 ### Option 1: Convert MusicXML Files
 ```bash
-# Convert a .mxl file to a playable .txt song file
-python convert_mxl_dual_clef.py loop.mxl
-python convert_mxl_dual_clef.py M2M_Pretty_Boy.mxl
+# Convert a .mxl file to a playable .txt song file using the converter module
+python -c "import converter; converter.parse_file('source_files/loop.mxl')"
+python -c "import converter; converter.parse_file('source_files/M2M_Pretty_Boy.mxl')"
 
 # The converted files will be saved in the songs/ directory
+The converter analyses tempo and time signature to preserve the original
+feel of the piece and splits notes between left and right hands when
+needed.
 ```
 
 ### Export to Lua

--- a/converter.py
+++ b/converter.py
@@ -1,8 +1,16 @@
 # converter.py
 
 import os
-from collections import defaultdict
-from music21 import converter, note, chord, stream, instrument, pitch
+from music21 import (
+    converter,
+    note,
+    chord,
+    stream,
+    instrument,
+    pitch,
+    tempo as m21tempo,
+    meter,
+)
 
 # The pitch 'C4' is often considered the dividing line between hands in simple piano music.
 # This is a heuristic and may not be accurate for all pieces.
@@ -87,12 +95,18 @@ def parse_file(file_path):
 
     # --- Metadata Extraction ---
     tempo = 120  # Default tempo
-    if score.metronomeMarkBoundaries():
-        tempo = score.metronomeMarkBoundaries()[0][-1].number
+    tempos = list(score.recurse().getElementsByClass(m21tempo.MetronomeMark))
+    if tempos:
+        mark = tempos[0]
+        if mark.number is not None:
+            tempo = mark.number
+        elif mark.getQuarterBPM() is not None:
+            tempo = mark.getQuarterBPM()
 
-    time_signature = "4/4" # Default time signature
-    if score.getTimeSignatures():
-        ts = score.getTimeSignatures()[0]
+    time_signature = "4/4"  # Default time signature
+    signatures = list(score.recurse().getElementsByClass(meter.TimeSignature))
+    if signatures:
+        ts = signatures[0]
         time_signature = f"{ts.numerator}/{ts.denominator}"
 
     key_signature = "C major" # Default key signature
@@ -104,36 +118,52 @@ def parse_file(file_path):
         print("Warning: Could not determine key signature. Defaulting to C major.")
         
     # --- Note and Chord Processing ---
-    song_data = []
-
-    # Group elements by their start offset so chords can be constructed
-    notes_by_offset = defaultdict(list)
+    events = []
     for element in score.notesAndRests:
-        notes_by_offset[round(element.offset, 3)].append(element)
+        offset = round(element.offset, 3)
+        duration = round(element.duration.quarterLength, 3)
 
-    sorted_offsets = sorted(notes_by_offset.keys())
+        if isinstance(element, note.Rest):
+            events.append((offset, "Rest", "", duration))
+            continue
 
-    for idx, offset in enumerate(sorted_offsets):
-        group = notes_by_offset[offset]
-        # Determine duration based on the next event offset
-        if idx + 1 < len(sorted_offsets):
-            next_offset = sorted_offsets[idx + 1]
+        if isinstance(element, note.Note):
+            hand = "RH" if element.pitch >= note.Pitch(RIGHT_HAND_THRESHOLD) else "LH"
+            name = shift_pitch_to_range(element.pitch).nameWithOctave
+            events.append((offset, hand, name, duration))
+            continue
+
+        if isinstance(element, chord.Chord):
+            left = []
+            right = []
+            for n in element.notes:
+                n_name = shift_pitch_to_range(n.pitch).nameWithOctave
+                if n.pitch >= note.Pitch(RIGHT_HAND_THRESHOLD):
+                    right.append(n_name)
+                else:
+                    left.append(n_name)
+            if left:
+                left.sort(key=lambda n: pitch.Pitch(n))
+                events.append((offset, "LH", "-".join(left), duration))
+            if right:
+                right.sort(key=lambda n: pitch.Pitch(n))
+                events.append((offset, "RH", "-".join(right), duration))
+
+    # Sort and merge events that share offset, hand and duration
+    events.sort(key=lambda e: (e[0], e[1]))
+    merged = []
+    for evt in events:
+        if merged and evt[0] == merged[-1][0] and evt[1] == merged[-1][1] and evt[3] == merged[-1][3]:
+            merged[-1][2] = merged[-1][2] + "-" + evt[2] if merged[-1][2] else evt[2]
         else:
-            next_offset = offset + max(e.duration.quarterLength for e in group)
-        duration = next_offset - offset
+            merged.append(list(evt))
 
-        # Collect note names, ignoring rests if notes are present
-        note_names = [shift_pitch_to_range(e.pitch).nameWithOctave
-                      for e in group if isinstance(e, note.Note)]
-
-        if note_names:
-            note_names.sort(key=lambda n: pitch.Pitch(n))
-            h_element = chord.Chord(note_names) if len(note_names) > 1 else note.Note(note_names[0])
-            hand = get_hand(h_element)
-            pitch_str = "-".join(note_names)
-            song_data.append(f"{hand}:{pitch_str}:{duration}")
-        else:
+    song_data = []
+    for offset, hand, pitches, duration in merged:
+        if hand == "Rest":
             song_data.append(f"Rest:{duration}")
+        else:
+            song_data.append(f"{hand}:{pitches}:{duration}")
             
     # --- Write to Output File ---
     if not song_data:


### PR DESCRIPTION
## Summary
- refine README instructions for converting and add note about hand splitting
- overhaul converter to read tempo/time signatures more robustly
- produce per-hand events with precise durations

## Testing
- `python -m py_compile converter.py main.py player.py key_mapper.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687dbea7037c83298e339287fa6afc54