### PR TITLE
Add tempo override and warn on multiple time signatures

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,8 +79,28 @@ def run_converter():
     # Get the selected file and call the converter
     selected_file = source_files[selected_file_index]
     file_path = os.path.join(SOURCE_FILES_DIR, selected_file)
-    
-    converter.parse_file(file_path)
+
+    metadata = converter.detect_metadata(file_path)
+    if metadata is None:
+        input("\nPress Enter to return to the menu.")
+        return
+    default_tempo, time_sig, sigs = metadata
+    if len(sigs) > 1:
+        print(
+            f"Warning: Multiple time signatures found: {', '.join(sigs)}. Using {time_sig}."
+        )
+
+    bpm_input = input(
+        f"Detected tempo is {default_tempo} BPM. Enter a BPM to override or press Enter to keep: "
+    )
+    tempo_override = default_tempo
+    if bpm_input.strip():
+        try:
+            tempo_override = float(bpm_input)
+        except ValueError:
+            print("Invalid BPM entered. Using detected tempo.")
+
+    converter.parse_file(file_path, tempo_override)
     
     input("\nPress Enter to return to the main menu.")
 


### PR DESCRIPTION
## Summary
- allow specifying tempo when converting files
- warn when more than one time signature is found during conversion
- prompt for BPM override in menu before converting

## Testing
- `python -m py_compile converter.py main.py player.py key_mapper.py`

------
https://chatgpt.com/codex/tasks/task_e_687dd55819208329979262a7f54f2839