### PR TITLE
Fix note extraction in converter

### DIFF
--- a/piano_assistant/converter.py
+++ b/piano_assistant/converter.py
@@ -39,8 +39,9 @@ def convert(file_path: str) -> str:
         raise ValueError('No notes found in file')
     shift = _compute_shift(min(midi_numbers), max(midi_numbers))
     score = score.transpose(shift)
+    flat_score = score.flatten()
     events = []
-    for entry in score.secondsMap:
+    for entry in flat_score.secondsMap:
         el = entry['element']
         if isinstance(el, (note.Note, chord.Chord)):
             start = entry['offsetSeconds']


### PR DESCRIPTION
## Summary
- ensure `secondsMap` iterates over note events

## Testing
- `python - <<'EOF'
from piano_assistant.converter import convert
from music21 import corpus
out = convert(str(corpus.getWork('bach/bwv66.6')))
print('Created', out)
print('First line:')
print(open(out).readline().strip())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687fbdb3a374832988677115e0f71796