### PR TITLE
Fix playable range checks when converting songs

### DIFF
--- a/piano_assistant/converter.py
+++ b/piano_assistant/converter.py
@@ -11,13 +11,15 @@ PLAYABLE_MAX = BASE_MIDI + 36 - 1
 
 
 def _compute_shift(min_note: int, max_note: int) -> int:
-    target_mid = (PLAYABLE_MIN + PLAYABLE_MAX) // 2
-    song_mid = (min_note + max_note) // 2
-    shift = 12 * round((target_mid - song_mid) / 12)
-    while min_note + shift < PLAYABLE_MIN:
-        shift += 12
-    while max_note + shift > PLAYABLE_MAX:
-        shift -= 12
+    """Return a semitone shift so all notes fit within the playable range."""
+    playable_span = PLAYABLE_MAX - PLAYABLE_MIN
+    if max_note - min_note > playable_span:
+        raise ValueError('Song range exceeds playable keyboard span')
+
+    shift = PLAYABLE_MIN - min_note
+    if max_note + shift > PLAYABLE_MAX:
+        shift = PLAYABLE_MAX - max_note
+
     return shift
 
 


### PR DESCRIPTION
## Summary
- validate note range when converting MIDI files
- compute transposition by semitone instead of octaves

## Testing
- `python - <<'PY'
from music21 import stream, note
from piano_assistant.converter import convert

s=stream.Stream()
for p in [40,75]:
    n=note.Note()
    n.pitch.midi=p
    s.append(n)
path='/tmp/test_range.mid'
s.write('midi', fp=path)
print(convert(path))
PY`

------
https://chatgpt.com/codex/tasks/task_e_687fbf169978832993f5b377971e7ede