### PR TITLE
Handle range errors when converting songs

### DIFF
--- a/piano_assistant/menu.py
+++ b/piano_assistant/menu.py
@@ -34,7 +34,11 @@ def convert_menu():
     src = select_source_file()
     if not src:
         return
-    out_path = converter.convert(src)
+    try:
+        out_path = converter.convert(src)
+    except ValueError as e:
+        console.print(f"[red]Failed to convert:[/red] {e}")
+        return
     console.print(f"Saved to [green]{out_path}[/green]")
 
 


### PR DESCRIPTION
## Summary
- catch `ValueError` in the convert menu so the app doesn't crash on large-range songs

## Testing
- `python3 -m compileall -q piano_assistant`

------
https://chatgpt.com/codex/tasks/task_e_687fc46d2e0083298126b6999de2b9cd