### PR TITLE
Fix polyphonic playback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ simple text representation and can replay the score using the PC keyboard.
   notes fit within the mapped three-octave range. If the song spans more than
   three octaves, notes outside the range are shifted by octaves individually to
   stay playable.
+- Supports overlapping notes so chords and polyphonic passages are reproduced
+  accurately during playback.
 
 ## Usage
 

--- a/piano_assistant/player.py
+++ b/piano_assistant/player.py
@@ -12,6 +12,7 @@ def _parse_note(note_str: str) -> str:
 
 
 def play(song_path: str):
+    """Play back a converted song file with support for overlapping notes."""
     events = []
     with open(song_path) as f:
         for line in f:
@@ -20,14 +21,37 @@ def play(song_path: str):
             start, dur, notes = line.strip().split('\t')
             note_keys = [_parse_note(n) for n in notes.split('+')]
             events.append((float(start), float(dur), note_keys))
-    events.sort(key=lambda x: x[0])
-    start_time = time.time()
+
+    # Build key press/release actions so that notes starting at the same time
+    # will overlap correctly instead of playing sequentially.
+    actions: List[tuple[float, str, List[str]]] = []
     for start, dur, keys in events:
-        wait = start - (time.time() - start_time)
+        actions.append((start, 'down', keys))
+        actions.append((start + dur, 'up', keys))
+    actions.sort(key=lambda x: x[0])
+
+    start_time = time.time()
+    pressed: dict[str, int] = {}
+
+    for action_time, action, keys in actions:
+        wait = action_time - (time.time() - start_time)
         if wait > 0:
             time.sleep(wait)
         for k in keys:
-            pyautogui.keyDown(k)
-        time.sleep(dur)
-        for k in keys:
+            if action == 'down':
+                # Only press the key if it isn't already pressed.
+                if pressed.get(k, 0) == 0:
+                    pyautogui.keyDown(k)
+                pressed[k] = pressed.get(k, 0) + 1
+            else:
+                # Only release when the last overlapping note finishes.
+                count = pressed.get(k, 0)
+                if count > 0:
+                    if count == 1:
+                        pyautogui.keyUp(k)
+                    pressed[k] = count - 1
+
+    # Ensure all keys are released at the end in case of any mismatch.
+    for k, count in pressed.items():
+        if count > 0:
             pyautogui.keyUp(k)

--- a/piano_assistant/tester.py
+++ b/piano_assistant/tester.py
@@ -9,19 +9,38 @@ def _parse_note(note_str: str) -> str:
 
 
 def test(song_path: str):
+    """Print simulated key presses for a song, respecting overlapping notes."""
+    events = []
     with open(song_path) as f:
-        events = []
         for line in f:
             if line.startswith('#') or not line.strip():
                 continue
             start, dur, notes = line.strip().split('\t')
             events.append((float(start), float(dur), notes))
-    events.sort(key=lambda x: x[0])
-    start_time = time.time()
+
+    actions = []
     for start, dur, notes in events:
-        wait = start - (time.time() - start_time)
+        keys = [_parse_note(n) for n in notes.split('+')]
+        actions.append((start, 'down', notes, keys))
+        actions.append((start + dur, 'up', notes, keys))
+    actions.sort(key=lambda x: x[0])
+
+    start_time = time.time()
+    pressed: dict[str, int] = {}
+
+    for action_time, action, note_str, keys in actions:
+        wait = action_time - (time.time() - start_time)
         if wait > 0:
             time.sleep(wait)
-        keys = [_parse_note(n) for n in notes.split('+')]
-        print(f"Play {notes} -> {keys} for {dur:.2f}s")
-        time.sleep(dur)
+        for k in keys:
+            if action == 'down':
+                if pressed.get(k, 0) == 0:
+                    print(f"Press {k}")
+                pressed[k] = pressed.get(k, 0) + 1
+            else:
+                count = pressed.get(k, 0)
+                if count > 0:
+                    if count == 1:
+                        print(f"Release {k}")
+                    pressed[k] = count - 1
+


### PR DESCRIPTION
## Summary
- add overlapping note playback in `player`
- update tester for overlapping playback events
- mention polyphonic support in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc9aa693c832981346c1bbd1b5dc6