### PR TITLE
Improve overlap timing

### DIFF
--- a/piano_assistant/player.py
+++ b/piano_assistant/player.py
@@ -28,7 +28,11 @@ def play(song_path: str):
     for start, dur, keys in events:
         actions.append((start, 'down', keys))
         actions.append((start + dur, 'up', keys))
-    actions.sort(key=lambda x: x[0])
+    # Sort by time and ensure that releases happen before presses when
+    # they share the same timestamp. This keeps rapid note repetitions
+    # in sync between hands and prevents keys from remaining held down
+    # when a new note should retrigger the same key.
+    actions.sort(key=lambda x: (x[0], 0 if x[1] == 'up' else 1))
 
     start_time = time.time()
     pressed: dict[str, int] = {}

--- a/piano_assistant/tester.py
+++ b/piano_assistant/tester.py
@@ -23,7 +23,10 @@ def test(song_path: str):
         keys = [_parse_note(n) for n in notes.split('+')]
         actions.append((start, 'down', notes, keys))
         actions.append((start + dur, 'up', notes, keys))
-    actions.sort(key=lambda x: x[0])
+    # Sort so that key releases occur before presses at the same time.
+    # This mirrors the behaviour of ``player.play`` and keeps
+    # overlapping notes from drifting out of sync during rapid passages.
+    actions.sort(key=lambda x: (x[0], 0 if x[1] == 'up' else 1))
 
     start_time = time.time()
     pressed: dict[str, int] = {}


### PR DESCRIPTION
## Summary
- ensure release actions are sorted before press actions so hands stay in sync
- apply same ordering logic to tester tool

## Testing
- `python - <<'PY'
from piano_assistant.tester import test
print('Testing repeated:')
test('piano_assistant/output/repeat_20250722_173730.txt')
print('Testing tie:')
test('piano_assistant/output/test_tie_20250722_173637.txt')
PY
`

------
https://chatgpt.com/codex/tasks/task_e_687fcafbcab48329821c3e15dd0a5cea