### PR TITLE
Add metadata display for songs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ simple text representation and can replay the score using the PC keyboard.
 
 - Lists all `*.mid` and `*.mxl` files found in `piano_assistant/source_files`.
 - Converts a selected file to a timestamped text file in
-  `piano_assistant/output`.
+  `piano_assistant/output`. Converted files include the original time signature
+  and tempo in comment lines for reference during playback.
 - Plays back converted songs using `pyautogui` and a fixed three octave key
-  mapping.
+  mapping. When playing back a converted song, the program prints metadata such
+  as the source file name, time signature, and tempo so you can verify the
+  conversion.
 - Test mode prints which keys would be played without sending any keystrokes.
 - Automatically transposes the entire song up or down in octave steps so all
   notes fit within the mapped three-octave range. If the song spans more than

--- a/piano_assistant/tester.py
+++ b/piano_assistant/tester.py
@@ -10,13 +10,24 @@ def _parse_note(note_str: str) -> str:
 
 def test(song_path: str):
     """Print simulated key presses for a song, respecting overlapping notes."""
+    metadata: dict[str, str] = {}
     events = []
     with open(song_path) as f:
         for line in f:
-            if line.startswith('#') or not line.strip():
+            if line.startswith('#'):
+                if ':' in line:
+                    key, value = line[1:].split(':', 1)
+                    metadata[key.strip()] = value.strip()
+                continue
+            if not line.strip():
                 continue
             start, dur, notes = line.strip().split('\t')
             events.append((float(start), float(dur), notes))
+
+    if metadata:
+        print("Song Info")
+        for key, val in metadata.items():
+            print(f"{key}: {val}")
 
     actions = []
     for start, dur, notes in events:


### PR DESCRIPTION
## Summary
- include tempo and time signature when converting songs
- show source, time signature and tempo when playing or testing
- mention song metadata in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from music21 import stream, note, meter, tempo
from piano_assistant import converter
import os
s = stream.Stream()
s.append(meter.TimeSignature('3/4'))
s.append(tempo.MetronomeMark(number=90))
for pitch in ['C4','D4','E4']:
    s.append(note.Note(pitch, quarterLength=1))
os.makedirs('piano_assistant/source_files', exist_ok=True)
path = 'piano_assistant/source_files/test.mid'
s.write('midi', path)
print('written', path)
print('out:', converter.convert(path))
PY`
- `python - <<'PY'
from piano_assistant import tester

tester.test('piano_assistant/output/test_20250722_175622.txt')
PY`

------
https://chatgpt.com/codex/tasks/task_e_687fcff6439883298ed5f7ba510d20e2