### PR TITLE
Add tempo and meter change support

### DIFF
--- a/piano_assistant/player.py
+++ b/piano_assistant/player.py
@@ -1,5 +1,5 @@
 import time
-from typing import List
+from typing import List, Tuple
 
 import pyautogui
 from rich.console import Console
@@ -14,34 +14,91 @@ def _parse_note(note_str: str) -> str:
     return KEY_MAPPING[(name, int(octave))]
 
 
-def play(song_path: str):
-    """Play back a converted song file with support for overlapping notes."""
+def _read_song(song_path: str) -> Tuple[dict, List[Tuple[float, float]], List[Tuple[float, str]], List[Tuple[float, float, str]]]:
+    """Parse a converted song file.
+
+    Returns metadata, tempo events, time signature events and note events.
+    """
     metadata: dict[str, str] = {}
-    events = []
+    tempo_events: List[Tuple[float, float]] = []
+    ts_events: List[Tuple[float, str]] = []
+    events: List[Tuple[float, float, str]] = []
+
     with open(song_path) as f:
         for line in f:
             if line.startswith('#'):
-                if ':' in line:
+                if line.startswith('# Tempo '):
+                    rest = line[len('# Tempo '):].strip()
+                    off_str, val = rest.split(':', 1)
+                    bpm = float(val.replace('BPM', '').strip())
+                    tempo_events.append((float(off_str), bpm))
+                elif line.startswith('# TimeSignature '):
+                    rest = line[len('# TimeSignature '):].strip()
+                    off_str, val = rest.split(':', 1)
+                    ts_events.append((float(off_str), val.strip()))
+                elif ':' in line:
                     key, value = line[1:].split(':', 1)
                     metadata[key.strip()] = value.strip()
                 continue
             if not line.strip():
                 continue
             start, dur, notes = line.strip().split('\t')
-            note_keys = [_parse_note(n) for n in notes.split('+')]
-            events.append((float(start), float(dur), note_keys))
+            events.append((float(start), float(dur), notes))
+    tempo_events.sort(key=lambda x: x[0])
+    ts_events.sort(key=lambda x: x[0])
+    return metadata, tempo_events, ts_events, events
 
-    if metadata:
+
+def _beat_to_sec(beat: float, tempo_events: List[Tuple[float, float]], default_bpm: float = 120.0) -> float:
+    """Convert a beat position to seconds according to tempo events."""
+    tempo_events = sorted(tempo_events, key=lambda x: x[0])
+    if tempo_events and tempo_events[0][0] > 0:
+        # Insert an initial tempo if none exists at offset 0
+        tempo_events = [(0.0, default_bpm)] + tempo_events
+    elif not tempo_events:
+        tempo_events = [(0.0, default_bpm)]
+
+    sec = 0.0
+    last_off, last_bpm = tempo_events[0]
+    if beat < last_off:
+        return (beat - 0) * 60.0 / last_bpm
+    sec += (last_off - 0) * 60.0 / last_bpm
+    for off, bpm in tempo_events[1:]:
+        if beat < off:
+            sec += (beat - last_off) * 60.0 / last_bpm
+            return sec
+        sec += (off - last_off) * 60.0 / last_bpm
+        last_off, last_bpm = off, bpm
+    sec += (beat - last_off) * 60.0 / last_bpm
+    return sec
+
+
+def play(song_path: str):
+    """Play back a converted song file with support for overlapping notes."""
+    metadata, tempo_events, ts_events, raw_events = _read_song(song_path)
+    events: List[Tuple[float, float, List[str]]] = []
+    for start, dur, notes in raw_events:
+        note_keys = [_parse_note(n) for n in notes.split('+')]
+        events.append((start, dur, note_keys))
+
+    if metadata or tempo_events or ts_events:
         console.print("[bold]Song Info[/bold]")
         for key, val in metadata.items():
             console.print(f"{key}: {val}")
+        for off, ts_val in ts_events:
+            console.print(f"TimeSignature @ {off}: {ts_val}")
+        for off, bpm in tempo_events:
+            console.print(f"Tempo @ {off}: {int(bpm)} BPM")
 
     # Build key press/release actions so that notes starting at the same time
-    # will overlap correctly instead of playing sequentially.
+    # will overlap correctly instead of playing sequentially. Convert beat
+    # positions to real seconds using the tempo map.
     actions: List[tuple[float, str, List[str]]] = []
     for start, dur, keys in events:
-        actions.append((start, 'down', keys))
-        actions.append((start + dur, 'up', keys))
+        start_sec = _beat_to_sec(start, tempo_events)
+        end_sec = _beat_to_sec(start + dur, tempo_events)
+        actions.append((start_sec, 'down', keys))
+        actions.append((end_sec, 'up', keys))
     # Sort by time and ensure that releases happen before presses when
     # they share the same timestamp. This keeps rapid note repetitions
     # in sync between hands and prevents keys from remaining held down

--- a/tests/test_tempo_meter.py
+++ b/tests/test_tempo_meter.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import pytest
+from music21 import stream, note, meter, tempo
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from piano_assistant.converter import convert
+from piano_assistant import tester
+
+
+def create_score(path):
+    s = stream.Score()
+    p = stream.Part()
+    p.insert(0, meter.TimeSignature('4/4'))
+    p.insert(0, tempo.MetronomeMark(number=120))
+    for i in range(4):
+        p.insert(i, note.Note('C4', quarterLength=1))
+    p.insert(4, meter.TimeSignature('3/4'))
+    p.insert(4, tempo.MetronomeMark(number=60))
+    for i in range(3):
+        p.insert(4 + i, note.Note('C4', quarterLength=1))
+    s.insert(0, p)
+    xml_path = os.path.join(path, 'test.mxl')
+    s.write('musicxml', fp=xml_path)
+    return xml_path
+
+
+def test_conversion_and_playback(tmp_path):
+    xml = create_score(tmp_path)
+    out_path = convert(str(xml))
+    with open(out_path) as f:
+        lines = [l.strip() for l in f if l.strip()]
+
+    assert any(line.startswith('# TimeSignature 0.000: 4/4') for line in lines)
+    assert any(line.startswith('# Tempo 0.000: 120 BPM') for line in lines)
+    assert any(line.startswith('# TimeSignature 4.000: 3/4') for line in lines)
+    assert any(line.startswith('# Tempo 4.000: 60 BPM') for line in lines)
+
+    metadata, tempos, tss, events = tester._read_song(out_path)
+    starts = [tester._beat_to_sec(start, tempos) for start, _dur, _notes in events]
+    expected = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0]
+    assert starts == pytest.approx(expected, abs=1e-3)


### PR DESCRIPTION
## Summary
- track all tempo and time signature changes during conversion
- store tempo and meter events in output files with offsets
- adjust playback and testing utilities to honour tempo events
- add regression test with tempo and meter changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880437be57883298f34ff931f2cc5d1