### PR TITLE
Handle headless mode for pyautogui

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ simple text representation and can replay the score using the PC keyboard.
 
    ```bash
    pip install -r requirements.txt
+   # For headless environments, also install pyvirtualdisplay
+   pip install pyvirtualdisplay
    ```
 
 2. Place MIDI or MXL files in `piano_assistant/source_files/`.
@@ -39,3 +41,10 @@ simple text representation and can replay the score using the PC keyboard.
 
 Follow the on-screen menu to convert or play songs. Converted files are stored
 in `piano_assistant/output/` with a timestamp in the filename.
+
+## Display Requirements
+
+`pyautogui` needs access to an X display. The program will attempt to start a
+virtual display automatically when the `DISPLAY` environment variable is not
+set. On headless systems install `pyvirtualdisplay` as shown above or configure
+a display manually.

--- a/piano_assistant/player.py
+++ b/piano_assistant/player.py
@@ -1,5 +1,19 @@
+import os
+import atexit
 import time
 from typing import List
+
+if not os.environ.get("DISPLAY"):
+    try:
+        from pyvirtualdisplay import Display
+        _virtual_display = Display()
+        _virtual_display.start()
+        atexit.register(_virtual_display.stop)
+    except Exception as e:
+        raise RuntimeError(
+            "No display found. Set the DISPLAY environment variable or install pyvirtualdisplay "
+            "to run in headless mode."
+        ) from e
 
 import pyautogui
 from rich.console import Console


### PR DESCRIPTION
## Summary
- start a virtual display when DISPLAY is not defined
- document pyvirtualdisplay usage in README

## Testing
- `python -m py_compile piano_assistant/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6880437be8388329a538f9fde474717a