### PR TITLE
Add argparse CLI with module entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ simple text representation and can replay the score using the PC keyboard.
 
 2. Place MIDI or MXL files in `piano_assistant/source_files/`.
 
-3. Run the program:
+3. Use the CLI to convert, play, or test songs. For example:
 
    ```bash
-   python -m piano_assistant.main
+   python -m piano_assistant.cli convert path/to/file.mid
+   python -m piano_assistant.cli play piano_assistant/output/converted.txt
+   python -m piano_assistant.cli test piano_assistant/output/converted.txt
    ```
 
-Follow the on-screen menu to convert or play songs. Converted files are stored
-in `piano_assistant/output/` with a timestamp in the filename.
+Converted files are stored in `piano_assistant/output/` with a timestamp in the
+filename.

--- a/piano_assistant/cli.py
+++ b/piano_assistant/cli.py
@@ -1,0 +1,40 @@
+import argparse
+from rich.console import Console
+
+console = Console()
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Piano Assistant command line interface")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    p_convert = subparsers.add_parser("convert", help="Convert a MIDI/MXL file")
+    p_convert.add_argument("path", help="Path to a MIDI or MusicXML file")
+
+    p_play = subparsers.add_parser("play", help="Play a converted song file")
+    p_play.add_argument("path", help="Path to a converted song text file")
+
+    p_test = subparsers.add_parser("test", help="Test a converted song file")
+    p_test.add_argument("path", help="Path to a converted song text file")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "convert":
+        from . import converter
+        try:
+            out = converter.convert(args.path)
+        except Exception as exc:
+            console.print(f"[red]Failed to convert:[/red] {exc}")
+            return 1
+        console.print(f"Saved to [green]{out}[/green]")
+    elif args.command == "play":
+        from . import player
+        player.play(args.path)
+    elif args.command == "test":
+        from . import tester
+        tester.test(args.path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/piano_assistant/main.py
+++ b/piano_assistant/main.py
@@ -1,12 +1,11 @@
 from rich.console import Console
 from rich.prompt import Prompt
 
-from . import menu
-
 console = Console()
 
 
-def main():
+def interactive_main():
+    from . import menu
     while True:
         console.print("\n[bold cyan]Piano Assistant[/bold cyan]")
         console.print("[1] Convert Song")
@@ -25,4 +24,5 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    from .cli import main as cli_main
+    cli_main()


### PR DESCRIPTION
## Summary
- create `piano_assistant/cli.py` providing `convert`, `play` and `test` commands
- call this CLI when running `python -m piano_assistant.main`
- document CLI usage in README

## Testing
- `python -m piano_assistant.cli --help`
- `python -m piano_assistant.cli play --help`
- `python -m piano_assistant.main --help`


------
https://chatgpt.com/codex/tasks/task_e_6880437eed1c8329bbe98defa5e97a4d