### PR TITLE
Improve converter by merging tied notes

### DIFF
--- a/piano_assistant/converter.py
+++ b/piano_assistant/converter.py
@@ -54,6 +54,10 @@ def _round_time(value: float) -> float:
 
 def convert(file_path: str) -> str:
     score = m21converter.parse(file_path)
+    # Merge tied notes so sustained pitches become single longer notes.
+    # This allows the player to hold notes for their full duration instead of
+    # re-triggering ties as separate events.
+    score = score.stripTies(inPlace=False)
 
     # Extract basic metadata for reference during playback and collect all
     # time signature and tempo changes along with their offsets.

--- a/tests/test_strip_ties.py
+++ b/tests/test_strip_ties.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import pytest
+from music21 import stream, note, meter, tie
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from piano_assistant.converter import convert
+
+
+def create_tied_score(path):
+    s = stream.Score()
+    p = stream.Part()
+    p.insert(0, meter.TimeSignature('4/4'))
+    n1 = note.Note('C4', quarterLength=2)
+    n1.tie = tie.Tie('start')
+    n2 = note.Note('C4', quarterLength=2)
+    n2.tie = tie.Tie('stop')
+    p.append(n1)
+    p.append(n2)
+    s.insert(0, p)
+    xml_path = os.path.join(path, 'tied.mxl')
+    s.write('musicxml', fp=xml_path)
+    return xml_path
+
+
+def test_tied_notes_merged(tmp_path):
+    xml = create_tied_score(tmp_path)
+    out_path = convert(str(xml))
+    lines = [l.strip() for l in open(out_path) if l.strip()]
+    data_lines = [l for l in lines if not l.startswith('#')]
+    assert len(data_lines) == 1
+    start, dur, _notes = data_lines[0].split('\t')
+    assert pytest.approx(float(dur), abs=1e-3) == 4.0
+


### PR DESCRIPTION
## Summary
- merge tied notes before conversion so sustains are preserved
- test that ties spanning measures are combined

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68807f7e42e483299f10605313509cd5