### PR TITLE
Add tempo utilities and seconds conversion option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ simple text representation and can replay the score using the PC keyboard.
 - Lists all `*.mid` and `*.mxl` files found in `piano_assistant/source_files`.
 - Converts a selected file to a timestamped text file in
   `piano_assistant/output`. Converted files include the original time signature
-  and tempo in comment lines for reference during playback.
+  and tempo in comment lines for reference during playback. Start and duration
+  values are measured in beats by default so playback can follow tempo changes.
+  The ``piano_assistant.converter.convert`` function also accepts
+  ``use_seconds=True`` to output times in seconds instead.
 - Plays back converted songs using `pyautogui` and a fixed three octave key
   mapping. When playing back a converted song, the program prints metadata such
   as the source file name, time signature, and tempo so you can verify the

--- a/piano_assistant/player.py
+++ b/piano_assistant/player.py
@@ -24,6 +24,7 @@ import pyautogui
 from rich.console import Console
 
 from .key_mapper import KEY_MAPPING
+from .tempo_utils import beat_to_sec
 
 console = Console()
 
@@ -68,28 +69,6 @@ def _read_song(song_path: str) -> Tuple[dict, List[Tuple[float, float]], List[Tu
     return metadata, tempo_events, ts_events, events
 
 
-def _beat_to_sec(beat: float, tempo_events: List[Tuple[float, float]], default_bpm: float = 120.0) -> float:
-    """Convert a beat position to seconds according to tempo events."""
-    tempo_events = sorted(tempo_events, key=lambda x: x[0])
-    if tempo_events and tempo_events[0][0] > 0:
-        # Insert an initial tempo if none exists at offset 0
-        tempo_events = [(0.0, default_bpm)] + tempo_events
-    elif not tempo_events:
-        tempo_events = [(0.0, default_bpm)]
-
-    sec = 0.0
-    last_off, last_bpm = tempo_events[0]
-    if beat < last_off:
-        return (beat - 0) * 60.0 / last_bpm
-    sec += (last_off - 0) * 60.0 / last_bpm
-    for off, bpm in tempo_events[1:]:
-        if beat < off:
-            sec += (beat - last_off) * 60.0 / last_bpm
-            return sec
-        sec += (off - last_off) * 60.0 / last_bpm
-        last_off, last_bpm = off, bpm
-    sec += (beat - last_off) * 60.0 / last_bpm
-    return sec
 
 
 def play(song_path: str):
@@ -114,8 +93,8 @@ def play(song_path: str):
     # positions to real seconds using the tempo map.
     actions: List[tuple[float, str, List[str]]] = []
     for start, dur, keys in events:
-        start_sec = _beat_to_sec(start, tempo_events)
-        end_sec = _beat_to_sec(start + dur, tempo_events)
+        start_sec = beat_to_sec(start, tempo_events)
+        end_sec = beat_to_sec(start + dur, tempo_events)
         actions.append((start_sec, 'down', keys))
         actions.append((end_sec, 'up', keys))
     # Sort by time and ensure that releases happen before presses when

--- a/piano_assistant/tempo_utils.py
+++ b/piano_assistant/tempo_utils.py
@@ -1,0 +1,27 @@
+"""Utility functions for tempo calculations."""
+
+from typing import List, Tuple
+
+
+def beat_to_sec(beat: float, tempo_events: List[Tuple[float, float]], default_bpm: float = 120.0) -> float:
+    """Convert a beat position to seconds using the provided tempo map."""
+    tempo_events = sorted(tempo_events, key=lambda x: x[0])
+    if tempo_events and tempo_events[0][0] > 0:
+        # Insert an initial tempo if none exists at offset 0
+        tempo_events = [(0.0, default_bpm)] + tempo_events
+    elif not tempo_events:
+        tempo_events = [(0.0, default_bpm)]
+
+    sec = 0.0
+    last_off, last_bpm = tempo_events[0]
+    if beat < last_off:
+        return (beat - 0) * 60.0 / last_bpm
+    sec += (last_off - 0) * 60.0 / last_bpm
+    for off, bpm in tempo_events[1:]:
+        if beat < off:
+            sec += (beat - last_off) * 60.0 / last_bpm
+            return sec
+        sec += (off - last_off) * 60.0 / last_bpm
+        last_off, last_bpm = off, bpm
+    sec += (beat - last_off) * 60.0 / last_bpm
+    return sec

--- a/tests/test_tempo_meter.py
+++ b/tests/test_tempo_meter.py
@@ -37,6 +37,6 @@ def test_conversion_and_playback(tmp_path):
     assert any(line.startswith('# Tempo 4.000: 60 BPM') for line in lines)
 
     metadata, tempos, tss, events = tester._read_song(out_path)
-    starts = [tester._beat_to_sec(start, tempos) for start, _dur, _notes in events]
+    starts = [tester.beat_to_sec(start, tempos) for start, _dur, _notes in events]
     expected = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0]
     assert starts == pytest.approx(expected, abs=1e-3)

--- a/tests/test_use_seconds.py
+++ b/tests/test_use_seconds.py
@@ -1,0 +1,52 @@
+import os
+import sys
+
+import pytest
+from music21 import stream, note, meter, tempo
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from piano_assistant.converter import convert
+from piano_assistant.tempo_utils import beat_to_sec
+
+
+def create_score(path):
+    s = stream.Score()
+    p = stream.Part()
+    p.insert(0, meter.TimeSignature('4/4'))
+    p.insert(0, tempo.MetronomeMark(number=120))
+    for i in range(4):
+        p.insert(i, note.Note('C4', quarterLength=1))
+    p.insert(4, meter.TimeSignature('3/4'))
+    p.insert(4, tempo.MetronomeMark(number=60))
+    for i in range(3):
+        p.insert(4 + i, note.Note('C4', quarterLength=1))
+    s.insert(0, p)
+    xml_path = os.path.join(path, 'seconds.mxl')
+    s.write('musicxml', fp=xml_path)
+    return xml_path
+
+
+def test_use_seconds(tmp_path):
+    xml = create_score(tmp_path)
+    out_path = convert(str(xml), use_seconds=True)
+    with open(out_path) as f:
+        lines = [l.strip() for l in f if l.strip()]
+    data_lines = [l for l in lines if not l.startswith('#')]
+
+    starts = []
+    durs = []
+    for line in data_lines:
+        start, dur, _ = line.split('\t')
+        starts.append(float(start))
+        durs.append(float(dur))
+
+    tempo_events = [(0.0, 120.0), (4.0, 60.0)]
+    beat_positions = [0, 1, 2, 3, 4, 5, 6]
+    expected_starts = [beat_to_sec(b, tempo_events) for b in beat_positions]
+    expected_durs = [
+        beat_to_sec(b + 1, tempo_events) - beat_to_sec(b, tempo_events)
+        for b in beat_positions
+    ]
+
+    assert starts == pytest.approx(expected_starts, abs=1e-3)
+    assert durs == pytest.approx(expected_durs, abs=1e-3)


### PR DESCRIPTION
## Summary
- factor out `beat_to_sec` into new `tempo_utils` module
- use the shared helper in player and tester
- allow `converter.convert()` to output times in seconds
- document the default beat units and new option
- test new seconds mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688083fa9f348329bfcafe80ac9a804c