### PR TITLE
Add seconds option in convert menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ simple text representation and can replay the score using the PC keyboard.
    python -m piano_assistant.main
    ```
 
-Follow the on-screen menu to convert or play songs. Converted files are stored
-in `piano_assistant/output/` with a timestamp in the filename.
+Follow the on-screen menu to convert or play songs. When converting, you can
+choose to output start times and durations in beats or seconds. Converted files
+are stored in `piano_assistant/output/` with a timestamp in the filename.
 
 ## Display Requirements
 

--- a/piano_assistant/menu.py
+++ b/piano_assistant/menu.py
@@ -34,8 +34,12 @@ def convert_menu():
     src = select_source_file()
     if not src:
         return
+    use_seconds = False
+    answer = Prompt.ask("Output timings in seconds?", choices=["y", "n"], default="n")
+    if answer.lower() == "y":
+        use_seconds = True
     try:
-        out_path = converter.convert(src)
+        out_path = converter.convert(src, use_seconds=use_seconds)
     except ValueError as e:
         console.print(f"[red]Failed to convert:[/red] {e}")
         return


### PR DESCRIPTION
## Summary
- add menu prompt to optionally output timings in seconds
- forward the chosen option to `converter.convert`
- document the interactive choice in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880899512ac8329baaf5a2b734c463d