### PR TITLE
Fix duplicate meta events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 *.swp
 *.swo
 *~
+piano_assistant/output/

--- a/piano_assistant/converter.py
+++ b/piano_assistant/converter.py
@@ -79,6 +79,14 @@ def convert(file_path: str, use_seconds: bool = False) -> str:
         tempo_events.append((off, float(tempo_elem.number)))
         if initial_bpm is None:
             initial_bpm = int(tempo_elem.number)
+
+    # Remove duplicate offset/value pairs while preserving order
+    ts_events = sorted(set(ts_events), key=lambda x: x[0])
+    tempo_events = sorted(set(tempo_events), key=lambda x: x[0])
+    if ts_events:
+        initial_ts = ts_events[0][1]
+    if tempo_events:
+        initial_bpm = int(tempo_events[0][1])
     midi_numbers: List[int] = []
     for elem in score.recurse().notes:
         if isinstance(elem, note.Note):

--- a/tests/test_dedup_events.py
+++ b/tests/test_dedup_events.py
@@ -1,0 +1,36 @@
+import os
+import sys
+from music21 import stream, note, meter, tempo
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from piano_assistant.converter import convert
+
+
+def create_score(path):
+    s = stream.Score()
+    p1 = stream.Part()
+    p1.insert(0, meter.TimeSignature('4/4'))
+    p1.insert(0, tempo.MetronomeMark(number=120))
+    p1.append(note.Note('C4', quarterLength=1))
+
+    p2 = stream.Part()
+    p2.insert(0, meter.TimeSignature('4/4'))
+    p2.insert(0, tempo.MetronomeMark(number=120))
+    p2.append(note.Note('E4', quarterLength=1))
+
+    s.insert(0, p1)
+    s.insert(0, p2)
+    xml_path = os.path.join(path, 'dedup.mxl')
+    s.write('musicxml', fp=xml_path)
+    return xml_path
+
+
+def test_dedup_events(tmp_path):
+    xml = create_score(tmp_path)
+    out_path = convert(str(xml))
+    with open(out_path) as f:
+        lines = [l.strip() for l in f if l.strip()]
+    ts_lines = [l for l in lines if l.startswith('# TimeSignature')]
+    tempo_lines = [l for l in lines if l.startswith('# Tempo')]
+    assert ts_lines.count('# TimeSignature 0.000: 4/4') == 1
+    assert tempo_lines.count('# Tempo 0.000: 120 BPM') == 1


### PR DESCRIPTION
## Summary
- drop duplicate `(offset, value)` pairs when collecting time signature and tempo events
- update initial `Time Signature` and `Tempo` after deduplication
- ignore converted output files
- add regression test to ensure deduplicated events

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880899570e483298a576e47d94b78c4