### PR TITLE
Refactor song reading helper

### DIFF
--- a/piano_assistant/file_parser.py
+++ b/piano_assistant/file_parser.py
@@ -1,0 +1,34 @@
+from typing import List, Tuple
+
+
+def _read_song(song_path: str) -> Tuple[dict, List[Tuple[float, float]], List[Tuple[float, str]], List[Tuple[float, float, str]]]:
+    """Parse a converted song file and return metadata, tempo events, time
+    signature events, and note events."""
+    metadata: dict[str, str] = {}
+    tempo_events: List[Tuple[float, float]] = []
+    ts_events: List[Tuple[float, str]] = []
+    events: List[Tuple[float, float, str]] = []
+
+    with open(song_path) as f:
+        for line in f:
+            if line.startswith('#'):
+                if line.startswith('# Tempo '):
+                    rest = line[len('# Tempo '):].strip()
+                    off_str, val = rest.split(':', 1)
+                    bpm = float(val.replace('BPM', '').strip())
+                    tempo_events.append((float(off_str), bpm))
+                elif line.startswith('# TimeSignature '):
+                    rest = line[len('# TimeSignature '):].strip()
+                    off_str, val = rest.split(':', 1)
+                    ts_events.append((float(off_str), val.strip()))
+                elif ':' in line:
+                    key, value = line[1:].split(':', 1)
+                    metadata[key.strip()] = value.strip()
+                continue
+            if not line.strip():
+                continue
+            start, dur, notes = line.strip().split('\t')
+            events.append((float(start), float(dur), notes))
+    tempo_events.sort(key=lambda x: x[0])
+    ts_events.sort(key=lambda x: x[0])
+    return metadata, tempo_events, ts_events, events

--- a/piano_assistant/player.py
+++ b/piano_assistant/player.py
@@ -3,6 +3,8 @@ import atexit
 import time
 from typing import List, Tuple
 
+from .file_parser import _read_song
+
 # Start a virtual X display when running on Linux without an available DISPLAY.
 # Windows and macOS provide a display by default, so attempting to launch
 # ``pyvirtualdisplay`` there would fail. Only attempt to use a virtual display
@@ -32,41 +34,6 @@ console = Console()
 def _parse_note(note_str: str) -> str:
     name, octave = note_str.split('-')
     return KEY_MAPPING[(name, int(octave))]
-
-
-def _read_song(song_path: str) -> Tuple[dict, List[Tuple[float, float]], List[Tuple[float, str]], List[Tuple[float, float, str]]]:
-    """Parse a converted song file.
-
-    Returns metadata, tempo events, time signature events and note events.
-    """
-    metadata: dict[str, str] = {}
-    tempo_events: List[Tuple[float, float]] = []
-    ts_events: List[Tuple[float, str]] = []
-    events: List[Tuple[float, float, str]] = []
-
-    with open(song_path) as f:
-        for line in f:
-            if line.startswith('#'):
-                if line.startswith('# Tempo '):
-                    rest = line[len('# Tempo '):].strip()
-                    off_str, val = rest.split(':', 1)
-                    bpm = float(val.replace('BPM', '').strip())
-                    tempo_events.append((float(off_str), bpm))
-                elif line.startswith('# TimeSignature '):
-                    rest = line[len('# TimeSignature '):].strip()
-                    off_str, val = rest.split(':', 1)
-                    ts_events.append((float(off_str), val.strip()))
-                elif ':' in line:
-                    key, value = line[1:].split(':', 1)
-                    metadata[key.strip()] = value.strip()
-                continue
-            if not line.strip():
-                continue
-            start, dur, notes = line.strip().split('\t')
-            events.append((float(start), float(dur), notes))
-    tempo_events.sort(key=lambda x: x[0])
-    ts_events.sort(key=lambda x: x[0])
-    return metadata, tempo_events, ts_events, events
 
 
 

--- a/piano_assistant/tester.py
+++ b/piano_assistant/tester.py
@@ -4,46 +4,12 @@ from typing import List, Tuple
 
 from .key_mapper import KEY_MAPPING
 from .tempo_utils import beat_to_sec
+from .file_parser import _read_song
 
 
 def _parse_note(note_str: str) -> str:
     name, octave = note_str.split('-')
     return KEY_MAPPING[(name, int(octave))]
-
-
-def _read_song(song_path: str) -> Tuple[dict, List[Tuple[float, float]], List[Tuple[float, str]], List[Tuple[float, float, str]]]:
-    """Parse a converted song file and return metadata, tempo events,
-    time signature events, and note events."""
-    metadata: dict[str, str] = {}
-    tempo_events: List[Tuple[float, float]] = []
-    ts_events: List[Tuple[float, str]] = []
-    events: List[Tuple[float, float, str]] = []
-
-    with open(song_path) as f:
-        for line in f:
-            if line.startswith('#'):
-                if line.startswith('# Tempo '):
-                    rest = line[len('# Tempo '):].strip()
-                    off_str, val = rest.split(':', 1)
-                    bpm = float(val.replace('BPM', '').strip())
-                    tempo_events.append((float(off_str), bpm))
-                elif line.startswith('# TimeSignature '):
-                    rest = line[len('# TimeSignature '):].strip()
-                    off_str, val = rest.split(':', 1)
-                    ts_events.append((float(off_str), val.strip()))
-                elif ':' in line:
-                    key, value = line[1:].split(':', 1)
-                    metadata[key.strip()] = value.strip()
-                continue
-            if not line.strip():
-                continue
-            start, dur, notes = line.strip().split('\t')
-            events.append((float(start), float(dur), notes))
-    tempo_events.sort(key=lambda x: x[0])
-    ts_events.sort(key=lambda x: x[0])
-    return metadata, tempo_events, ts_events, events
-
-
 
 
 def test(song_path: str):


### PR DESCRIPTION
## Summary
- move `_read_song` helper to new `file_parser` module
- use the shared helper in `player` and `tester`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880899816c883299084f161c34fc80b